### PR TITLE
SeitanCLock: update RTC only on sucessfull NTP query

### DIFF
--- a/version.h
+++ b/version.h
@@ -1,1 +1,1 @@
-#define VERSION "0.2.0"
+#define VERSION "0.2.1"


### PR DESCRIPTION
Seems that during network errors NTP time may be set to incorrect ones. Adding retries and updating RTC only if NTP query is successful.
