### PR TITLE
SeitanClock: fix date formatting

### DIFF
--- a/displays/HT16K33/display.cpp
+++ b/displays/HT16K33/display.cpp
@@ -5,7 +5,7 @@ be aware of +- posioningm (it may differ from RTC module).
 */
 
 
-#include "1config.h"
+#include "config.h"
 #include "clock.h"
 #include <HT16K33.h>
 
@@ -40,7 +40,7 @@ void displayYear(configStructure *cfg, rtcData *tm) {
 }
 
 void displayMonthDay(configStructure *cfg, rtcData *tm) {
-  seg.displayTime(tm->month, tm->day, 0);
+  seg.displayDate(tm->month, tm->day);
 }
 
 void displayFlashMode(configStructure *cfg) {

--- a/version.h
+++ b/version.h
@@ -1,1 +1,1 @@
-#define VERSION "0.2.1"
+#define VERSION "0.2.2"


### PR DESCRIPTION
Use leading zero and dot separator in date display
